### PR TITLE
Fix Dapr-related configuration

### DIFF
--- a/src/run-feedercan.sh
+++ b/src/run-feedercan.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+# Copyright (c) 2022-2023 Robert Bosch GmbH and Microsoft Corporation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at
@@ -23,7 +23,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 CONFIG_DIR="$SCRIPT_DIR/data"
 
 export VEHICLEDATABROKER_DAPR_APP_ID=vehicledatabroker
-export DAPR_GRPC_PORT=52001
 export LOG_LEVEL=info,databroker=info,dbcfeeder.broker_client=info,dbcfeeder=info
 export USECASE=databroker
 
@@ -38,20 +37,21 @@ then
     docker container stop $RUNNING_CONTAINER
 fi
 
-docker run \
+dapr run \
+    --app-id feedercan \
+    --app-protocol grpc \
+    --components-path $VELOCITAS_WORKSPACE_DIR/.dapr/components \
+    --config $VELOCITAS_WORKSPACE_DIR/.dapr/config.yaml \
+-- docker run \
     -v ${CONFIG_DIR}:/data \
     -e VEHICLEDATABROKER_DAPR_APP_ID \
     -e DAPR_GRPC_PORT \
+    -e DAPR_HTTP_PORT \
     -e LOG_LEVEL \
     -e USECASE \
     -e CANDUMP_FILE \
     -e DBC_FILE \
     -e MAPPING_FILE \
     --network host \
-    $FEEDERCAN_IMAGE:$FEEDERCAN_TAG &
+    $FEEDERCAN_IMAGE:$FEEDERCAN_TAG
 
-dapr run \
-    --app-id feedercan \
-    --app-protocol grpc \
-    --components-path $VELOCITAS_WORKSPACE_DIR/.dapr/components \
-    --config $VELOCITAS_WORKSPACE_DIR/.dapr/config.yaml && fg

--- a/src/run-vehicledatabroker.sh
+++ b/src/run-vehicledatabroker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+# Copyright (c) 2022-2023 Robert Bosch GmbH and Microsoft Corporation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at
@@ -19,8 +19,7 @@ echo "#######################################################"
 
 VSPEC_FILE_PATH=$(echo $VELOCITAS_CACHE_DATA | jq .vspec_file_path | tr -d '"')
 
-DATABROKER_PORT='55555'
-export DATABROKER_GRPC_PORT='52001'
+KUKSA_DATA_BROKER_PORT='55555'
 #export RUST_LOG="info,databroker=debug,vehicle_data_broker=debug"
 
 RUNNING_CONTAINER=$(docker ps | grep "$DATABROKER_IMAGE" | awk '{ print $1 }')
@@ -30,18 +29,18 @@ then
     docker container stop $RUNNING_CONTAINER
 fi
 
-docker run \
-    `if [ ! "$VSPEC_FILE_PATH" == null ] && [ -n "$VSPEC_FILE_PATH" ]; then echo "-v $VSPEC_FILE_PATH:$VSPEC_FILE_PATH -e KUKSA_DATA_BROKER_METADATA_FILE=$VSPEC_FILE_PATH"; fi` \
-    -e DATABROKER_GRPC_PORT \
-    -p $DATABROKER_PORT:$DATABROKER_PORT \
-    -p $DATABROKER_GRPC_PORT:$DATABROKER_GRPC_PORT \
-    --network host \
-    $DATABROKER_IMAGE:$DATABROKER_TAG &
-
 dapr run \
     --app-id vehicledatabroker \
     --app-protocol grpc \
-    --app-port $DATABROKER_PORT \
-    --dapr-grpc-port $DATABROKER_GRPC_PORT \
+    --app-port $KUKSA_DATA_BROKER_PORT \
     --components-path $VELOCITAS_WORKSPACE_DIR/.dapr/components \
-    --config $VELOCITAS_WORKSPACE_DIR/.dapr/config.yaml && fg
+    --config $VELOCITAS_WORKSPACE_DIR/.dapr/config.yaml \
+-- docker run \
+    `if [ ! "$VSPEC_FILE_PATH" == null ] && [ -n "$VSPEC_FILE_PATH" ]; then echo "-v $VSPEC_FILE_PATH:$VSPEC_FILE_PATH -e KUKSA_DATA_BROKER_METADATA_FILE=$VSPEC_FILE_PATH"; fi` \
+    -e KUKSA_DATA_BROKER_PORT \
+    -e DAPR_GRPC_PORT \
+    -e DAPR_HTTP_PORT \
+    -e RUST_LOG \
+    --network host \
+    $DATABROKER_IMAGE:$DATABROKER_TAG
+

--- a/src/run-vehicleservices.sh
+++ b/src/run-vehicleservices.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+# Copyright (c) 2022-2023 Robert Bosch GmbH and Microsoft Corporation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at
@@ -21,18 +21,13 @@ echo "#######################################################"
 configure_service() {
     case $1 in
         seatservice)
-            SEATSERVICE_PORT=50051
-            SEATSERVICE_GRPC_PORT=52002
-            CAN=cansim
-            VEHICLEDATABROKER_DAPR_APP_ID=vehicledatabroker
-            # Configure ports for docker to expose
-            DOCKER_PORTS="-p $SEATSERVICE_PORT:$SEATSERVICE_PORT -p $SEATSERVICE_GRPC_PORT:$SEATSERVICE_GRPC_PORT"
+            export SERVICE_PORT=50051
+            export CAN=cansim
+            export VEHICLEDATABROKER_DAPR_APP_ID=vehicledatabroker
+            # Configure docker networking, e.g. ports for docker to expose
+            DOCKER_NET_CONFIG="--network host"
             # Configure ENVs need to run docker container
-            DOCKER_ENVS="-e VEHICLEDATABROKER_DAPR_APP_ID=$VEHICLEDATABROKER_DAPR_APP_ID -e CAN=$CAN -e DAPR_GRPC_PORT=$SEATSERVICE_GRPC_PORT"
-            # Configure Dapr App Port
-            DAPR_APP_PORT=$SEATSERVICE_PORT
-            # Configure Dapr Grpc Port
-            DAPR_GRPC_PORT=$SEATSERVICE_GRPC_PORT
+            DOCKER_ENVS="-e VEHICLEDATABROKER_DAPR_APP_ID -e CAN -e DAPR_GRPC_PORT -e DAPR_HTTP_PORT -e SERVICE_PORT"
             ;;
         *)
             echo "Unknown Service to configure."
@@ -51,15 +46,13 @@ run_service() {
         docker container stop $RUNNING_CONTAINER
     fi
 
-    docker run $DOCKER_PORTS $DOCKER_ENVS --network host $SERVICE_IMAGE:$SERVICE_TAG &
-
     dapr run \
         --app-id $SERVICE_NAME \
         --app-protocol grpc \
-        --app-port $DAPR_APP_PORT \
-        --dapr-grpc-port $DAPR_GRPC_PORT \
+        --app-port $SERVICE_PORT \
         --components-path $VELOCITAS_WORKSPACE_DIR/.dapr/components \
-        --config $VELOCITAS_WORKSPACE_DIR/.dapr/config.yaml &
+        --config $VELOCITAS_WORKSPACE_DIR/.dapr/config.yaml \
+    -- docker run $DOCKER_NET_CONFIG $DOCKER_ENVS $SERVICE_IMAGE:$SERVICE_TAG &
 }
 
 DEPENDENCIES=$(echo $VELOCITAS_APP_MANIFEST | jq .dependencies)
@@ -84,3 +77,4 @@ else
 fi
 
 wait
+


### PR DESCRIPTION
Contains Dapr-related fixes and improvements:
* The dbc-feeder is now connecting to its own Dapr sidecar (instead of that of the data broker)
* Sidecar ports are now defined implicitly by Dapr run and communicated to the applications via env variables (DAPR_GRPC_PORT, DAPR_HTTP_PORT)
* Service port numbers (if any) are passed from the runtime script to the application, so that the default number could be changed

ADO: 13340